### PR TITLE
Renamed delegate methods to be compatible with swift

### DIFF
--- a/CRMediaPickerController/CRMediaPickerController.h
+++ b/CRMediaPickerController/CRMediaPickerController.h
@@ -26,8 +26,8 @@ typedef NS_OPTIONS(NSInteger, CRMediaPickerControllerSourceType) {
 @protocol CRMediaPickerControllerDelegate <NSObject>
 
 @optional
-- (void)CRMediaPickerController:(CRMediaPickerController *)mediaPickerController didFinishPickingAsset:(ALAsset *)asset error:(NSError *)error;
-- (void)CRMediaPickerControllerDidCancel:(CRMediaPickerController *)mediaPickerController;
+- (void)mediaPickerController:(CRMediaPickerController *)mediaPickerController didFinishPickingAsset:(ALAsset *)asset error:(NSError *)error;
+- (void)mediaPickerControllerDidCancel:(CRMediaPickerController *)mediaPickerController;
 @end
 
 @interface CRMediaPickerController: NSObject

--- a/CRMediaPickerController/CRMediaPickerController.m
+++ b/CRMediaPickerController/CRMediaPickerController.m
@@ -82,9 +82,9 @@
 
 - (void)dismiss
 {
-    if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerControllerDidCancel:)]) {
+    if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerControllerDidCancel:)]) {
         [self.imagePickerController.presentingViewController dismissViewControllerAnimated:YES completion:^{
-            [self.delegate CRMediaPickerControllerDidCancel:self];
+            [self.delegate mediaPickerControllerDidCancel:self];
         }];
     } else {
         [self.imagePickerController.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
@@ -361,8 +361,8 @@
         
         if (group.numberOfAssets == 0) {
             
-            if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerController:didFinishPickingAsset:error:)]) {
-                [self.delegate CRMediaPickerController:self didFinishPickingAsset:nil error:nil];
+            if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAsset:error:)]) {
+                [self.delegate mediaPickerController:self didFinishPickingAsset:nil error:nil];
             }
             
         } else {
@@ -372,8 +372,8 @@
                     return;
                 }
                 
-                if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerController:didFinishPickingAsset:error:)]) {
-                    [self.delegate CRMediaPickerController:self didFinishPickingAsset:asset error:nil];
+                if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAsset:error:)]) {
+                    [self.delegate mediaPickerController:self didFinishPickingAsset:asset error:nil];
                 }
                 
                 *innerStop = YES;
@@ -385,8 +385,8 @@
         
     } failureBlock:^(NSError *error) {
         
-        if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerController:didFinishPickingAsset:error:)]) {
-            [self.delegate CRMediaPickerController:self didFinishPickingAsset:nil error:error];
+        if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAsset:error:)]) {
+            [self.delegate mediaPickerController:self didFinishPickingAsset:nil error:error];
         }
         
     }];
@@ -407,8 +407,8 @@
     } else if ([buttonTitle isEqualToString:NSLocalizedString(@"Saved Photos", nil)]) {
         sourceType = UIImagePickerControllerSourceTypeSavedPhotosAlbum;
     } else if ([buttonTitle isEqualToString:NSLocalizedString(@"Cancel", nil)]) {
-        if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerControllerDidCancel:)]) {
-            [self.delegate CRMediaPickerControllerDidCancel:self];
+        if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerControllerDidCancel:)]) {
+            [self.delegate mediaPickerControllerDidCancel:self];
         }
         return;
     }
@@ -423,8 +423,8 @@
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker
 {
     [picker.presentingViewController dismissViewControllerAnimated:YES completion:^{
-        if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerControllerDidCancel:)]) {
-            [self.delegate CRMediaPickerControllerDidCancel:self];
+        if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerControllerDidCancel:)]) {
+            [self.delegate mediaPickerControllerDidCancel:self];
         }
     }];
 }
@@ -450,9 +450,9 @@
                         
                         [assetsLibrary assetForURL:assetURL resultBlock:^(ALAsset *asset) {
                             
-                            if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerController:didFinishPickingAsset:error:)]) {
+                            if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAsset:error:)]) {
                                 [picker.presentingViewController dismissViewControllerAnimated:YES completion:^{
-                                    [self.delegate CRMediaPickerController:self didFinishPickingAsset:asset error:nil];
+                                    [self.delegate mediaPickerController:self didFinishPickingAsset:asset error:nil];
                                 }];
                             } else {
                                 [picker.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
@@ -460,9 +460,9 @@
                             
                         } failureBlock:^(NSError *err) {
                             
-                            if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerController:didFinishPickingAsset:error:)]) {
+                            if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAsset:error:)]) {
                                 [picker.presentingViewController dismissViewControllerAnimated:YES completion:^{
-                                    [self.delegate CRMediaPickerController:self didFinishPickingAsset:nil error:err];
+                                    [self.delegate mediaPickerController:self didFinishPickingAsset:nil error:err];
                                 }];
                             } else {
                                 [picker.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
@@ -472,9 +472,9 @@
                         
                     } else {
                         
-                        if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerController:didFinishPickingAsset:error:)]) {
+                        if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAsset:error:)]) {
                             [picker.presentingViewController dismissViewControllerAnimated:YES completion:^{
-                                [self.delegate CRMediaPickerController:self didFinishPickingAsset:nil error:error];
+                                [self.delegate mediaPickerController:self didFinishPickingAsset:nil error:error];
                             }];
                         } else {
                             [picker.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
@@ -488,9 +488,9 @@
                 
                 [assetsLibrary assetForURL:referenceURL resultBlock:^(ALAsset *asset) {
                     
-                    if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerController:didFinishPickingAsset:error:)]) {
+                    if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAsset:error:)]) {
                         [picker.presentingViewController dismissViewControllerAnimated:YES completion:^{
-                            [self.delegate CRMediaPickerController:self didFinishPickingAsset:asset error:nil];
+                            [self.delegate mediaPickerController:self didFinishPickingAsset:asset error:nil];
                         }];
                     } else {
                         [picker.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
@@ -498,9 +498,9 @@
                     
                 } failureBlock:^(NSError *error) {
                     
-                    if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerController:didFinishPickingAsset:error:)]) {
+                    if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAsset:error:)]) {
                         [picker.presentingViewController dismissViewControllerAnimated:YES completion:^{
-                            [self.delegate CRMediaPickerController:self didFinishPickingAsset:nil error:error];
+                            [self.delegate mediaPickerController:self didFinishPickingAsset:nil error:error];
                         }];
                     } else {
                         [picker.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
@@ -531,9 +531,9 @@
                     
                     [assetsLibrary assetForURL:assetURL resultBlock:^(ALAsset *asset) {
                         
-                        if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerController:didFinishPickingAsset:error:)]) {
+                        if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAsset:error:)]) {
                             [picker.presentingViewController dismissViewControllerAnimated:YES completion:^{
-                                [self.delegate CRMediaPickerController:self didFinishPickingAsset:asset error:nil];
+                                [self.delegate mediaPickerController:self didFinishPickingAsset:asset error:nil];
                             }];
                         } else {
                             [picker.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
@@ -541,9 +541,9 @@
                         
                     } failureBlock:^(NSError *err) {
                         
-                        if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerController:didFinishPickingAsset:error:)]) {
+                        if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAsset:error:)]) {
                             [picker.presentingViewController dismissViewControllerAnimated:YES completion:^{
-                                [self.delegate CRMediaPickerController:self didFinishPickingAsset:nil error:err];
+                                [self.delegate mediaPickerController:self didFinishPickingAsset:nil error:err];
                             }];
                         } else {
                             [picker.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
@@ -553,9 +553,9 @@
                     
                 } else {
                     
-                    if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerController:didFinishPickingAsset:error:)]) {
+                    if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAsset:error:)]) {
                         [picker.presentingViewController dismissViewControllerAnimated:YES completion:^{
-                            [self.delegate CRMediaPickerController:self didFinishPickingAsset:nil error:error];
+                            [self.delegate mediaPickerController:self didFinishPickingAsset:nil error:error];
                         }];
                     } else {
                         [picker.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
@@ -569,9 +569,9 @@
             
             [assetsLibrary assetForURL:[info objectForKey:UIImagePickerControllerReferenceURL] resultBlock:^(ALAsset *asset) {
                 
-                if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerController:didFinishPickingAsset:error:)]) {
+                if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAsset:error:)]) {
                     [picker.presentingViewController dismissViewControllerAnimated:YES completion:^{
-                        [self.delegate CRMediaPickerController:self didFinishPickingAsset:asset error:nil];
+                        [self.delegate mediaPickerController:self didFinishPickingAsset:asset error:nil];
                     }];
                 } else {
                     [picker.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
@@ -579,9 +579,9 @@
                 
             } failureBlock:^(NSError *error) {
                 
-                if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerController:didFinishPickingAsset:error:)]) {
+                if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAsset:error:)]) {
                     [picker.presentingViewController dismissViewControllerAnimated:YES completion:^{
-                        [self.delegate CRMediaPickerController:self didFinishPickingAsset:nil error:error];
+                        [self.delegate mediaPickerController:self didFinishPickingAsset:nil error:error];
                     }];
                 } else {
                     [picker.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
@@ -624,8 +624,8 @@
 - (void)popoverControllerDidDismissPopover:(UIPopoverController *)popoverController
 {
     self.popoverController = nil;
-    if (self.delegate && [self.delegate respondsToSelector:@selector(CRMediaPickerControllerDidCancel:)]) {
-        [self.delegate CRMediaPickerControllerDidCancel:self];
+    if (self.delegate && [self.delegate respondsToSelector:@selector(mediaPickerControllerDidCancel:)]) {
+        [self.delegate mediaPickerControllerDidCancel:self];
     }
 }
 

--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/Example.xcscmblueprint
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/Example.xcscmblueprint
@@ -1,0 +1,30 @@
+{
+  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "E78B529B3E29A73BEA7969FC7095F6CA65F46FD5",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey" : {
+
+  },
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
+    "40069BF539098AEF7FE1C2D5534EA7025ADAA3D8" : 0,
+    "E78B529B3E29A73BEA7969FC7095F6CA65F46FD5" : 0
+  },
+  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "DB07EAAC-C230-425D-82CD-65FBC4DDE1AD",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
+    "40069BF539098AEF7FE1C2D5534EA7025ADAA3D8" : "",
+    "E78B529B3E29A73BEA7969FC7095F6CA65F46FD5" : "CRMediaPickerController\/"
+  },
+  "DVTSourceControlWorkspaceBlueprintNameKey" : "Example",
+  "DVTSourceControlWorkspaceBlueprintVersion" : 204,
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "Example\/Example.xcodeproj",
+  "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:SnowdogApps\/SDForms.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "40069BF539098AEF7FE1C2D5534EA7025ADAA3D8"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:dulal0026\/CRMediaPickerController.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "E78B529B3E29A73BEA7969FC7095F6CA65F46FD5"
+    }
+  ]
+}

--- a/Example/Example/ViewController.m
+++ b/Example/Example/ViewController.m
@@ -157,7 +157,7 @@
 
 #pragma mark - CPDMediaPickerControllerDelegate
 
-- (void)CRMediaPickerController:(CRMediaPickerController *)mediaPickerController didFinishPickingAsset:(ALAsset *)asset error:(NSError *)error
+- (void)mediaPickerController:(CRMediaPickerController *)mediaPickerController didFinishPickingAsset:(ALAsset *)asset error:(NSError *)error
 {
     if (!error) {
         
@@ -196,7 +196,7 @@
     }
 }
 
-- (void)CRMediaPickerControllerDidCancel:(CRMediaPickerController *)mediaPickerController
+- (void)mediaPickerControllerDidCancel:(CRMediaPickerController *)mediaPickerController
 {
     NSLog(@"%s", __PRETTY_FUNCTION__);
 }

--- a/README.md
+++ b/README.md
@@ -131,16 +131,16 @@ If `sourceType` property has multiple sources, it presents a UIActionSheet with 
 
 ### Delegate Methods
 
-A `CRMediaPickerController` instance will return the selected media file back to `CRMediaPickerControllerDelegate`. The delegate contains methods very similar to the `UIImagePickerControllerDelegate`. Instead of returning one dictionary representing a single image the controller sends back the original `ALAsset` object which are easy to deal with.
+A `CRMediaPickerController` instance will return the selected media file back to `mediaPickerControllerDelegate`. The delegate contains methods very similar to the `UIImagePickerControllerDelegate`. Instead of returning one dictionary representing a single image the controller sends back the original `ALAsset` object which are easy to deal with.
 
 * **Finished Picking Asset**
 
-`- CRMediaPickerController:didFinishPickingAsset:error:`
+`- mediaPickerController:didFinishPickingAsset:error:`
 
 Tells the delegate that the picking process is done and the media file is ready to use.
 
 ```objc
-- (void)CRMediaPickerController:(CRMediaPickerController *)mediaPickerController didFinishPickingAsset:(ALAsset *)asset error:(NSError *)error;
+- (void)mediaPickerController:(CRMediaPickerController *)mediaPickerController didFinishPickingAsset:(ALAsset *)asset error:(NSError *)error;
 ```
 
 Parameters:
@@ -164,12 +164,12 @@ Parameters:
 
 * **Cancelled**
 
-`- CRMediaPickerControllerDidCancel:`
+`- mediaPickerControllerDidCancel:`
 
 Tells the delegate that the user cancelled the picking process.
 
 ```objc
-- (void)CRMediaPickerControllerDidCancel:(CRMediaPickerController *)mediaPickerController;
+- (void)mediaPickerControllerDidCancel:(CRMediaPickerController *)mediaPickerController;
 ```
 
 Parameters:
@@ -188,7 +188,7 @@ Parameters:
 ```objc
 #pragma mark - CPDMediaPickerControllerDelegate
 
-- (void)CRMediaPickerController:(CRMediaPickerController *)mediaPickerController didFinishPickingAsset:(ALAsset *)asset error:(NSError *)error
+- (void)mediaPickerController:(CRMediaPickerController *)mediaPickerController didFinishPickingAsset:(ALAsset *)asset error:(NSError *)error
 {
     if (!error) {
         
@@ -227,7 +227,7 @@ Parameters:
     }
 }
 
-- (void)CRMediaPickerControllerDidCancel:(CRMediaPickerController *)mediaPickerController
+- (void)mediaPickerControllerDidCancel:(CRMediaPickerController *)mediaPickerController
 {
     NSLog(@"%s", __PRETTY_FUNCTION__);
 }


### PR DESCRIPTION
Tasks done:
[x] Renamed delegate methods not to be conflicting with constructor in swift
[x] Updated all method checks and calls to be compatible
[x] Updated example project accordingly
[x] Updated README
